### PR TITLE
specified version to fix greenfield installation error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask==2.2.3
 flask_sqlalchemy==3.0.3
 pyllamacpp==1.0.6
+Werkzeug==2.2.2
 langchain==0.0.147


### PR DESCRIPTION
was getting error roughly 'ImportError: cannot import name 'url_encode' '